### PR TITLE
feat: fix duration display

### DIFF
--- a/status.go
+++ b/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 	"time"
 )
 
@@ -83,14 +82,8 @@ func (s Status) Next() time.Time {
 }
 
 func shortNext(d time.Duration) time.Duration {
-	switch {
-	case d < time.Second:
-		return d.Truncate(time.Millisecond)
-	case d < time.Minute:
-		return d.Truncate(time.Second)
-	case d < time.Hour:
-		return d.Truncate(time.Minute)
+	if d < time.Second {
+		return d
 	}
-	// Otherwise truncate the number of hours to two decimal places.
-	return time.Duration(math.Round(d.Hours()*100) / 100)
+	return d.Round(time.Second)
 }

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,27 @@
+package redo
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestShortNext(t *testing.T) {
+	test := func(dur, want string) {
+		t.Helper()
+		dv, err := time.ParseDuration(dur)
+		if err != nil {
+			t.Fatalf("ivalid duration %q: %v", dur, err)
+		}
+		got := fmt.Sprintf("%v", shortNext(dv))
+		if got != want {
+			t.Errorf("want: %s, got %s", want, got)
+		}
+	}
+	test("0.5s", "500ms")
+	test("0.4s", "400ms")
+	test("1.4s", "1s")
+	test("1.90s", "2s")
+	test("66.3s", "1m6s")
+	test("3661.3s", "1h1m1s")
+}


### PR DESCRIPTION
don't bother with truncating, just display millis if < 1s, otherwise display standard duration without fractional seconds